### PR TITLE
fix tests for prng

### DIFF
--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -95,4 +95,21 @@ target_link_libraries(cncrypto
   PRIVATE
     ${EXTRA_LIBRARIES})
 
-
+if(BUILD_TESTS)
+  # if tests are enabled than build a special crypto library with a deterministic
+  # random number generator, this lib is than used for the test `crypto`
+  ryo_add_library(cncrypto_for_test
+    ${crypto_sources}
+    ${crypto_headers}
+    ${crypto_private_headers})
+  target_link_libraries(cncrypto_for_test
+    PUBLIC
+      epee
+      ${Boost_SYSTEM_LIBRARY}
+    PRIVATE
+      ${EXTRA_LIBRARIES})
+  target_compile_definitions(cncrypto_for_test
+      PUBLIC
+      -DCRYPTO_TEST_ONLY_FIXED_PRNG
+  )
+endif()

--- a/src/crypto/random.cpp
+++ b/src/crypto/random.cpp
@@ -68,7 +68,7 @@ extern "C" void* memwipe(void *src, size_t n);
 
 struct prng_handle
 {
-#if defined(CRYPTO_TEST_ONLY_FIXED_PRNG)
+#if defined( CRYPTO_TEST_ONLY_FIXED_PRNG)
 	uint64_t count = 0;
 #elif defined(_WIN32)
 	HCRYPTPROV prov;
@@ -82,18 +82,20 @@ prng::~prng()
 	if(hnd == nullptr)
 		return;
 
-#if defined(_WIN32)
+#if !defined(CRYPTO_TEST_ONLY_FIXED_PRNG)
+#	if defined(_WIN32)
 	if(!CryptReleaseContext(hnd->prov, 0))
 	{
 		std::cerr << "CryptReleaseContext" << std::endl;
 		std::abort();
 	}
-#else
+#	else
 	if(close(hnd->fd) < 0)
 	{
 		std::cerr << "Exit Failure :: close /dev/urandom " << std::endl; 
 		std::abort();
 	}
+#	endif
 #endif
 	delete hnd;
 }

--- a/tests/crypto/CMakeLists.txt
+++ b/tests/crypto/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(cncrypto-tests
   ${crypto_headers})
 target_link_libraries(cncrypto-tests
   PRIVATE
+    cncrypto_for_test
     common
     ${Boost_SYSTEM_LIBRARY}
     ${EXTRA_LIBRARIES})

--- a/tests/crypto/main.cpp
+++ b/tests/crypto/main.cpp
@@ -107,6 +107,7 @@ int main(int argc, char *argv[])
 		}
 		else if(cmd == "generate_keys")
 		{
+			// this test uses a deterministic random number generator in the backend
 			public_key expected1, actual1;
 			secret_key expected2, actual2;
 			get(input, expected1, expected2);
@@ -193,6 +194,7 @@ int main(int argc, char *argv[])
 		}
 		else if(cmd == "generate_signature")
 		{
+			// this test uses a deterministic random number generator in the backend
 			chash prefix_hash;
 			public_key pub;
 			secret_key sec;
@@ -253,6 +255,7 @@ int main(int argc, char *argv[])
 		}
 		else if(cmd == "generate_ring_signature")
 		{
+			// this test uses a deterministic random number generator in the backend  
 			chash prefix_hash;
 			key_image image;
 			vector<public_key> vpubs;


### PR DESCRIPTION
- CMake:
  - Create the cncrypto library two times, once for deamon and co and a special version with a deterministic random number generator for the crypto tests.
  - build a test library `cncrypto_for_test`
  - link crypto tests against `cncrypto_for_test`
- fix `random.cpp`: add missing define guard
-  fix crypto tests 
  - We use a new deterministic random number generator for the tests, therefore some hashes
differ compared to the old tests.
  - update hashes those depends on the RNG
  - add documentation to the test to see where the RNG effects the hashes

After you merged this to your open PR please rebase the full PR against #93 to test all with the fixed travis CI.